### PR TITLE
Set the version of elasticsearch explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to build Elasticsearch with our required plugins
 
-FROM elasticsearch
+FROM elasticsearch:1.7
 
 ADD config.yml /tmp/config.yml
 RUN cat /tmp/config.yml >> /usr/share/elasticsearch/config/elasticsearch.yml


### PR DESCRIPTION
Currently the automated build on dockerhub is broken because the method of installing the phonetic analysis plugin has changed in recent versions of Elasticsearch, and the Dockerfile is pulling the latest base Elasticsearch image.